### PR TITLE
Adding validators

### DIFF
--- a/launch/Initial_Validators.md
+++ b/launch/Initial_Validators.md
@@ -1,0 +1,51 @@
+# Initial Validators Set for Paseo Launch.
+
+The following validators with its correponding keys were added as invulnerables in the Paseo chain spec:
+
+## 5CADNSaxg4RVe8n45SDsE8hCcVvZV3StcVYi5yjEreRF9APt (PARANODES.IO)
+```
+    {
+      grandpa: 0xc8caee6f6eddc41c6cc55e554343392cbc13d2a8a57b97f6f85fc965bdd20ce8
+      babe: 0xb07d600e3487e2712dcc3879c7b17c9b29cd2243b45f0d9343c591b89cf82a65
+      imOnline: 0x0edf2a41cb81178704560b02c35f5e01a5a97a568ebc10c025ade18b6ab2fa1d
+      paraValidator: 0x161d0af40e6efc165c17d0189bd2d770bdfa0a9b8393cb89113f473a2e948c68
+      paraAssignment: 0xdef964eed9a73f8a6610f1a0373378dca6f277eb7787869ed5841893105ad930
+      authorityDiscovery: 0xf89c97bf5b2c07c05c84eebce4ffc7b28766946c03741fd1a71fdae0942e8768
+    }
+```
+
+## 5DDVAkXRMSkkmrB2yqrbFvPCZt8xaPawcy2bEvBsCJRRiUtm (AMFORC)
+```
+    {
+      grandpa: 0x8270a62b61639ee56113834aecec01de6cda91413a5111b89f74d6585da34f50
+      babe: 0x58108e1651614afc6a535c426fc013945e93533faa33819fe4e69423fe323302
+      imOnline: 0x74bd654c470ed9b94972c1f997593fab7bdd4d6b85e3cf49401265668142584e
+      paraValidator: 0xad90a2c3fa2c756f974628dd279adb87935f7ea509856276e3b86f759b22451c
+      paraAssignment: 0xc083b0d0bd7d6ffd14562b4c9e28738b087ccc32262170c633c18359ff848779
+      authorityDiscovery: 0x92cb05c48fc643f057626c669604675c5ad5a836266f260ae7030c6fdc17a543
+    }
+```
+
+# 5F2A2bL6WopW8NEmxQmABY8cLtYmdDjNzsiwnCDLtPn44orx (STAKE PLUS)
+```
+    {
+      grandpa: 0x4c669b04865e9acaf7b72bdfcb0099d70d9ec63c8c2d6b8cb0552815d7b50a0a
+      babe: 0xfacb2f987caac6c1290a9784b1efdba78343d39aed805addb12945efbe444000
+      imOnline: 0xca3c2703db1633a27eff681d979967988c3a6752c669fd41f1abde10f3b05446
+      paraValidator: 0x2253ee3c02d89582602ca5b0570cfc01dc82cc8d1b9d2071eb5db6318749124b
+      paraAssignment: 0xf0e6c42698fffc28f9fc769fddcdf165af54c171cde43690cc8f73c853de1f04
+      authorityDiscovery: 0x26e2fc857945d01520797a75388c58e710c9fefedd28387af70880f1682be41e
+    }
+```
+
+# 5FRWXfgHjZVXs7BSP4yBB2b8fgczRof5zynJjbgud6ptRrUA (DWELLIR)
+```
+    {
+      grandpa: 0xc9a68a26e9aa37ba6334f1a20275e3be7d3a9d4aa988627eadac8ea0d0a2dfbf
+      babe: 0xae240842b74e5dd778972e451558134f434c7a1d8a52bc70519f38054e245533
+      imOnline: 0x06bd8fd81e50cda2bd67bf6893d921d1aae5cb08409ae43e0bff4d54e1830e58
+      paraValidator: 0xea9400f05e7fb75a3f7a92febbf58e5a3060dd06132ed6d5d68a3d75ec452826
+      paraAssignment: 0xbed3b452f869d187be58a4ba98588611084283810728fa75981e792beaec4151
+      authorityDiscovery: 0x763d070989ead31f265b40cc7a0cd29d47799b766d6a7f084e44c82baedfc01e
+    }
+```

--- a/rfcs/Active_Paseo_Validators.md
+++ b/rfcs/Active_Paseo_Validators.md
@@ -1,7 +1,18 @@
 # Active Paseo Validators
 
-| Address | On Chain Identity | 
+| Address | On Chain Identity |
+| :----- | ----------- |
 | 5CADNSaxg4RVe8n45SDsE8hCcVvZV3StcVYi5yjEreRF9APt | PARANODES.IO |
 | 5DDVAkXRMSkkmrB2yqrbFvPCZt8xaPawcy2bEvBsCJRRiUtm | AMFORC |
 | 5F2A2bL6WopW8NEmxQmABY8cLtYmdDjNzsiwnCDLtPn44orx | STAKE PLUS |
 | 5FRWXfgHjZVXs7BSP4yBB2b8fgczRof5zynJjbgud6ptRrUA | DWELLIR |
+| 5CQN2L4soC8G6L3nngT42oTEc28BCmNvDEt5RwtpYV7QBScp | TURBOFLAKES.IO |
+| 5CkHkUKgay1bA77oFWBkaw83fjdX1yQaaBHtWAghTmzxAv1U | GATOTECH |
+| 5Ea38N1YzxnfDEkGRNixPE4oXALAuMK4XDoYpH4fyZahdrLL | PARITY-VALIDATOR-0 |
+| 5FJ7mri5qMgoAA1u6GptebqbPT1QXpPggoABrpgs2NJprKwz | COINSTUDIO |
+| 5FKoLJA8u17wewFsFsiEmgkywujgb8wWBB7gupaCSvxiWiC8 | HELIKON/ISTANBUL |
+| 5GnMSvfjUpRSwyQyzbrFfGqAS6vhBnLGtQCmPDikshemP4Jh | STKD.IO/01 |
+
+
+
+

--- a/rfcs/Active_Paseo_Validators.md
+++ b/rfcs/Active_Paseo_Validators.md
@@ -1,0 +1,7 @@
+# Active Paseo Validators
+
+| Address | On Chain Identity | 
+| 5CADNSaxg4RVe8n45SDsE8hCcVvZV3StcVYi5yjEreRF9APt | PARANODES.IO |
+| 5DDVAkXRMSkkmrB2yqrbFvPCZt8xaPawcy2bEvBsCJRRiUtm | AMFORC |
+| 5F2A2bL6WopW8NEmxQmABY8cLtYmdDjNzsiwnCDLtPn44orx | STAKE PLUS |
+| 5FRWXfgHjZVXs7BSP4yBB2b8fgczRof5zynJjbgud6ptRrUA | DWELLIR |

--- a/rfcs/Deactivated_Paseo_Validators.md
+++ b/rfcs/Deactivated_Paseo_Validators.md
@@ -1,0 +1,7 @@
+# Deactivated Paseo Validators
+
+| Address | On Chain Identity | 
+|  |  |
+|  |  |
+|  |  |
+|  |  |

--- a/rfcs/Deactivated_Paseo_Validators.md
+++ b/rfcs/Deactivated_Paseo_Validators.md
@@ -1,7 +1,7 @@
 # Deactivated Paseo Validators
 
 | Address | On Chain Identity | 
-|  |  |
+| :----- | ----------- |
 |  |  |
 |  |  |
 |  |  |


### PR DESCRIPTION
This PRs adds a couple of MD files that reflects the current Paseo validators status:

- `launch/Initial_Validators.md`: Documents the initial validator set  used for Paseo launch.
- `rfcs/Active_Paseo_Validators.md`:  Active validators
- `rfcs/Deactivated_Paseo_Validators.md`: For Deactivated validators (list is empty)