### PR TITLE
Documenting Session Times

### DIFF
--- a/launch/Session_Times.md
+++ b/launch/Session_Times.md
@@ -1,0 +1,10 @@
+# Paseo Session Times
+
+In order to have faster interactions as for example parachain onboarding, the Kusama session times have been set for Paseo:
+
+Block time: 6 secs.
+Epoch: 600 blocks (1 Hour)
+Era: 6 Epochs / 3600 blocks (6 Hours)
+
+Link to the configuration: https://github.com/paseo-network/runtimes/blob/main/relay/paseo/constants/src/lib.rs#L42:L60
+


### PR DESCRIPTION
As agreed, this MD documents the chosen Session times for Paseo network:

Block time: 6 secs.
Epoch: 600 blocks (1 Hour)
Era: 6 Epochs / 3600 blocks (6 Hours)

Link to the configuration: https://github.com/paseo-network/runtimes/blob/main/relay/paseo/constants/src/lib.rs#L42:L60
