### PR TITLE
Validator onboarding

### DIFF
--- a/paseo-validators/example.yml
+++ b/paseo-validators/example.yml
@@ -1,0 +1,22 @@
+# Identity to be set up for all validators running by Example
+identity:
+  display: Example
+  email: hi@example.io
+  website: https://example.io
+  twitter: @example
+  discord: example
+  riot: @example:matrix.org
+
+accounts:
+  # Here example is running two validators, 0 and 1
+  # It is not using a staking proxy account for 0
+  # As it is using a staking proxy for 1, it will receive some funds in that account as well to cover fees.
+  0:
+    stash: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+  1:
+    # Example provides a custom name for this concrete validator identity
+    # The rest of the fields will be taken from the defined above
+    identity:
+      display: Example-01
+    staking_proxy: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+    stash: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty


### PR DESCRIPTION
This PR adds an example of the file structure used to aggregate validators information introduced in #20 

This change might deprecate the previous listing of active/inactive validators: 
- `rfcs/Active_Paseo_Validators.md`
- `rfcs/Deactivated_Paseo_Validators.md`

This PR will be complete when:
- [ ] current active validators files have been created in [paseo-validators] folder.
- [ ] the corresponding github flow has been included to automate the process.
- [ ] a decision has been made and taken regarding the two above mentioned files. 

Closes:
- #20 